### PR TITLE
Use matrix displayname if available

### DIFF
--- a/src/Murmur.ts
+++ b/src/Murmur.ts
@@ -139,7 +139,7 @@ export default class Murmur {
     return;
   }
 
-  async sendMessage(event: MessageEvent, config: MurmurConfig) {
+  async sendMessage(event: MessageEvent, displayname : string, config: MurmurConfig) {
     if (!this.client || !this.server) {
       return;
     }
@@ -160,7 +160,7 @@ export default class Murmur {
 
     this.client.textMessageSend({
       server: this.server,
-      text: `${event.sender}: ${messageContent}`,
+      text: `${displayname}: ${messageContent}`,
     }, () => { });
 
     return;

--- a/src/Murmur.ts
+++ b/src/Murmur.ts
@@ -139,7 +139,7 @@ export default class Murmur {
     return;
   }
 
-  async sendMessage(event: MessageEvent, displayname : string, config: MurmurConfig) {
+  async sendMessage(event: MessageEvent, displayname?: string) {
     if (!this.client || !this.server) {
       return;
     }
@@ -156,6 +156,11 @@ export default class Murmur {
       && event.content.format === "org.matrix.custom.html"
       && event.content.formatted_body) {
       messageContent = event.content.formatted_body;
+    }
+
+    // If displayname was not provided, fall back to username
+    if (!displayname) {
+      displayname = event.sender;
     }
 
     this.client.textMessageSend({

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,7 @@ async function main() {
       console.log('Matrix-side listening on port %s', port);
       await murmur.setupCallbacks(bridge, config);
       bridge.run(port, config);
-      murmur.setMatrixClient(bridge.getClientFactory().getClientAs(null));
+      murmur.setMatrixClient(bridge.getClientFactory().getClientAs());
       return;
     },
   }).run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function main() {
         // @ts-ignore
         registration: 'mumble-registration.yaml',
         controller: {
-          onEvent: function(request: any, _context: any) {
+          onEvent: async function(request: any, _context: any) {
             const event = request.getData();
             if (event.type !== 'm.room.message' ||
                 !event.content || event.room_id !== config.matrixRoom) {
@@ -44,7 +44,18 @@ async function main() {
               return;
             }
 
-            murmur.sendMessage(event, config);
+            try {
+              // Retrieve the display name
+              const profile = await bridge.getIntent().getProfileInfo(event.sender, 'displayname');
+              var displayname = profile.displayname;
+            } catch (e) {
+              // Fall back to the Matrix ID
+              console.log('Exception fetching matrix profile of %s:', event.sender);
+              console.log(e);
+              var displayname = event.sender;
+            }
+
+            murmur.sendMessage(event, displayname, config);
             return;
           },
         },

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ async function main() {
         // @ts-ignore
         registration: 'mumble-registration.yaml',
         controller: {
-          onEvent: async function(request: any, _context: any) {
+          onEvent: async function (request: any, _context: any) {
             const event = request.getData();
             if (event.type !== 'm.room.message' ||
                 !event.content || event.room_id !== config.matrixRoom) {
@@ -44,18 +44,17 @@ async function main() {
               return;
             }
 
+            let displayname;
             try {
               // Retrieve the display name
               const profile = await bridge.getIntent().getProfileInfo(event.sender, 'displayname');
-              var displayname = profile.displayname;
+              displayname = profile.displayname;
             } catch (e) {
-              // Fall back to the Matrix ID
               console.log('Exception fetching matrix profile of %s:', event.sender);
               console.log(e);
-              var displayname = event.sender;
             }
 
-            murmur.sendMessage(event, displayname, config);
+            murmur.sendMessage(event, displayname);
             return;
           },
         },


### PR DESCRIPTION
Use the matrix displayname retrieved using getProfileInfo(), fixing
issue #3.

As far as I can tell (at least with synapse), this reports a displayname
even if one hasn't been explicitly set, however it will raise an
exception if the user doesn't exist, but given we just recieved a
message from the user that shouldn't happen.